### PR TITLE
chore: add permissions block to Build and Release Binaries workflow

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -1,5 +1,9 @@
 name: Build and Release Binaries
 
+permissions:
+  contents: write
+  packages: write
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -72,35 +72,20 @@ jobs:
           echo "📋 Checking generated native libraries:"
           find src/GrepSQL/runtimes/ -name "libpgquery_wrapper.*" -type f || echo "No native libraries found"
 
-      - name: Build for Windows (Placeholder)
+      - name: Build for Windows
         if: runner.os == 'Windows'
-        shell: cmd
+        shell: pwsh
         run: |
-          echo "🏗️ Building for Windows (partial support)..."
-          
-          REM Initialize submodules
           git submodule update --init --recursive
-          
-          REM Create placeholder directory structure
-          mkdir "src\GrepSQL\runtimes\win-x64\native" 2>nul
-          
-          REM Create a minimal dummy DLL to satisfy the .NET runtime
-          echo. > "src\GrepSQL\runtimes\win-x64\native\libpgquery_wrapper.dll"
-          
-          REM Build .NET project only
-          dotnet restore
-          dotnet build --configuration Release --no-restore
-          echo "⚠️ Windows build completed with placeholder native library"
+          ./scripts/build.ps1
 
       - name: Test (non-Windows)
         if: runner.os != 'Windows'
         run: dotnet test --configuration Release --no-build --verbosity normal
 
-      - name: Test (Windows - without native dependencies)
+      - name: Test (Windows)
         if: runner.os == 'Windows'
-        run: |
-          echo "Running limited tests on Windows..."
-          # dotnet test --configuration Release --no-build --verbosity normal --filter "Category!=RequiresNative"
+        run: dotnet test --configuration Release --no-build --verbosity normal
 
       - name: Publish GrepSQL Binary
         run: dotnet publish src/GrepSQL.CLI/GrepSQL/GrepSQL.csproj --configuration Release --runtime ${{ matrix.platform }} --self-contained true --output ./publish/${{ matrix.platform }} -p:PublishSingleFile=true -p:PublishTrimmed=true -p:IncludeNativeLibrariesForSelfExtract=true

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -72,6 +72,14 @@ jobs:
           echo "📋 Checking generated native libraries:"
           find src/GrepSQL/runtimes/ -name "libpgquery_wrapper.*" -type f || echo "No native libraries found"
 
+      - name: Install protoc on Windows
+        if: runner.os == 'Windows'
+        run: choco install protoc -y
+
+      - name: Setup MSVC environment
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@v1
+
       - name: Build for Windows
         if: runner.os == 'Windows'
         shell: pwsh
@@ -83,9 +91,37 @@ jobs:
         if: runner.os != 'Windows'
         run: dotnet test --configuration Release --no-build --verbosity normal
 
+      - name: Restore test project (Windows)
+        if: runner.os == 'Windows'
+        run: dotnet restore "tests/GrepSQL.Tests/GrepSQL.Tests.csproj"
+
+      - name: Build test project (Windows)
+        if: runner.os == 'Windows'
+        run: dotnet build "tests/GrepSQL.Tests/GrepSQL.Tests.csproj" --configuration Release -p:Platform="Any CPU" --no-restore
+
+      - name: Copy native wrapper for tests (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Remove-Item Env:Platform -ErrorAction SilentlyContinue
+
+          $testOut = "tests\GrepSQL.Tests\bin\Release\net9.0"
+          New-Item -ItemType Directory -Path $testOut -Force | Out-Null
+
+          Copy-Item `
+            -Path "src\GrepSQL\runtimes\win-x64\native\libpgquery_wrapper.dll" `
+            -Destination $testOut `
+            -Force
+
       - name: Test (Windows)
         if: runner.os == 'Windows'
-        run: dotnet test --configuration Release --no-build --verbosity normal
+        shell: pwsh
+        run: |
+          # Unset Platform so --no-build test finds the DLL
+          Remove-Item Env:Platform -ErrorAction SilentlyContinue
+          dotnet test "tests/GrepSQL.Tests/GrepSQL.Tests.csproj" `
+            --configuration Release `
+            --verbosity normal
 
       - name: Publish GrepSQL Binary
         run: dotnet publish src/GrepSQL.CLI/GrepSQL/GrepSQL.csproj --configuration Release --runtime ${{ matrix.platform }} --self-contained true --output ./publish/${{ matrix.platform }} -p:PublishSingleFile=true -p:PublishTrimmed=true -p:IncludeNativeLibrariesForSelfExtract=true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          submodules: recursive
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
@@ -53,26 +54,20 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y build-essential libc6-dev
 
-      - name: Run comprehensive build script
+      - name: Run build script (Windows)
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          ./scripts/build.ps1
+
+      - name: Run comprehensive build script (Unix)
+        if: matrix.os != 'windows-latest'
         shell: bash
         run: |
-          # Skip entire native build on Windows - needs different toolchain
-          if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
-            echo "🏗️ Building for Windows (partial support)..."
-            echo "Skipping native library build on Windows - .NET code will be tested without native dependencies"
-            echo "Windows would need MSVC/Visual Studio build tools for native compilation"
-            
-            # Initialize submodules and build .NET only
-            git submodule update --init --recursive
-            dotnet restore
-            dotnet build --configuration Release --no-restore
-            exit 0
-          fi
-          
           echo "🏗️ Running comprehensive build script..."
           chmod +x scripts/build.sh
           ./scripts/build.sh
-          
+
           # Verify the build was successful
           echo "📋 Verifying build output:"
           find src/GrepSQL/runtimes/ -name "libpgquery_wrapper.*" -type f || echo "No native libraries found"
@@ -121,7 +116,18 @@ jobs:
             echo "Warning: Native library not found at src/GrepSQL/runtimes/$TARGET_RID/native/libpgquery_wrapper.$LIBRARY_EXT"
             echo "Available files in src/GrepSQL/runtimes/:"
             find src/GrepSQL/runtimes/ -name "*.so" -o -name "*.dylib" || echo "No native libraries found"
-          fi
+        fi
+
+      - name: Copy native libraries to test project (Windows)
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          $TARGET_RID = 'win-x64'
+          $LIB_PATH = "src\GrepSQL\runtimes\$TARGET_RID\native\libpgquery_wrapper.dll"
+          $TEST_OUTPUT = "tests\GrepSQL.Tests\bin\Release\net9.0"
+          New-Item -ItemType Directory -Force -Path "$TEST_OUTPUT\runtimes\$TARGET_RID\native" | Out-Null
+          Copy-Item $LIB_PATH "$TEST_OUTPUT\runtimes\$TARGET_RID\native" -Force
+          Copy-Item $LIB_PATH $TEST_OUTPUT -Force
 
       - name: Run tests
         timeout-minutes: 10

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -1,4 +1,4 @@
-# GrepSQL Build Script for Windows
+﻿# GrepSQL Build Script for Windows
 # Requires: Visual Studio Build Tools, Git, .NET SDK, Protocol Buffers compiler
 
 param(
@@ -19,48 +19,17 @@ $ProjectRoot = Split-Path -Parent $ScriptDir
 # Configuration
 $LibPgQueryBranch = "17-latest"
 $LibPgQueryRepo = "https://github.com/pganalyze/libpg_query.git"
-$TargetRid = "win-x64"
+$TargetRid = "win-x64" # Crucial for native compilation and .NET builds
 
 Set-Location $ProjectRoot
 
 # Step 1: Check prerequisites
 Write-Host "🔍 Checking prerequisites..." -ForegroundColor Yellow
-
-# Check for Git
 if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
-    Write-Error "Git is required but not found in PATH"
-    exit 1
+    Write-Error "Git is required but not found in PATH"; exit 1
 }
-
-# Check for .NET SDK
 if (-not (Get-Command dotnet -ErrorAction SilentlyContinue)) {
-    Write-Error ".NET SDK is required but not found in PATH"
-    exit 1
-}
-
-# Check for Visual Studio Build Tools
-$MSBuildPaths = @(
-    "${env:ProgramFiles}\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\MSBuild.exe",
-    "${env:ProgramFiles}\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin\MSBuild.exe",
-    "${env:ProgramFiles}\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe",
-    "${env:ProgramFiles}\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin\MSBuild.exe",
-    "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\MSBuild.exe",
-    "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin\MSBuild.exe",
-    "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin\MSBuild.exe",
-    "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\MSBuild.exe"
-)
-
-$MSBuild = $null
-foreach ($path in $MSBuildPaths) {
-    if (Test-Path $path) {
-        $MSBuild = $path
-        break
-    }
-}
-
-if (-not $MSBuild) {
-    Write-Warning "⚠️  MSBuild not found. Native library compilation may fail."
-    Write-Host "Please install Visual Studio Build Tools 2019 or later"
+    Write-Error ".NET SDK is required but not found in PATH"; exit 1
 }
 
 # Step 2: Clone and prepare libpg_query
@@ -71,7 +40,8 @@ if (-not $SkipNative) {
         Write-Host "Cloning libpg_query (branch: $LibPgQueryBranch)..."
         & git clone -b $LibPgQueryBranch $LibPgQueryRepo
         if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-    } else {
+    }
+    else {
         Write-Host "libpg_query already exists, updating..."
         Set-Location libpg_query
         & git fetch origin
@@ -80,225 +50,150 @@ if (-not $SkipNative) {
         Set-Location ..
     }
 
-    # Build libpg_query using Windows Makefile
     Write-Host "🔨 Building libpg_query for Windows..." -ForegroundColor Yellow
     Set-Location libpg_query
     
-    if ($MSBuild) {
-        # Try to build with Visual Studio
-        if (Test-Path "Makefile.msvc") {
-            Write-Host "Using Visual Studio tools..."
-            & nmake /F Makefile.msvc clean
-            & nmake /F Makefile.msvc
-        } else {
-            Write-Warning "Makefile.msvc not found, trying alternative approach..."
-            # Fallback: try to use make with WSL or similar
-            if (Get-Command make -ErrorAction SilentlyContinue) {
-                & make clean
-                & make
-            } else {
-                Write-Error "Cannot build libpg_query. Please install Visual Studio Build Tools or WSL."
-                exit 1
-            }
-        }
+    if (Test-Path "Makefile.msvc") {
+        Write-Host "Using Visual Studio tools (nmake)..."
+        & nmake /F Makefile.msvc clean
+        & nmake /F Makefile.msvc
+    }
+    else {
+        Write-Error "Makefile.msvc not found in libpg_query. Cannot proceed with Windows build."
+        exit 1
     }
     
-
     Set-Location $ProjectRoot
 
     # Step 2b: Build wrapper library
     Write-Host "🔧 Building wrapper library..." -ForegroundColor Yellow
+    
+    Write-Host "🧹 Cleaning up old build artifacts..."
+    Remove-Item -Path "wrapper.c", "wrapper.def", "libpgquery_wrapper.dll" -ErrorAction SilentlyContinue
 
     $WrapperPath = Join-Path $ProjectRoot "wrapper.c"
-    if (-not (Test-Path $WrapperPath)) {
-        Write-Host "Creating wrapper.c..."
-        @"
-#include \"libpg_query/pg_query.h\"
+    $DefPath = Join-Path $ProjectRoot "wrapper.def"
 
-PgQueryProtobufParseResult pg_query_parse_protobuf_wrapper(const char* input) {
-    return pg_query_parse_protobuf(input);
-}
+    Write-Host "Creating wrapper.c with __stdcall calling convention..."
+    @"
+#include "libpg_query/pg_query.h"
+#define STDCALL __stdcall
 
-PgQueryProtobufParseResult pg_query_parse_protobuf_opts_wrapper(const char* input, int parser_options) {
-    return pg_query_parse_protobuf_opts(input, parser_options);
-}
+PgQueryProtobufParseResult STDCALL pg_query_parse_protobuf_wrapper(const char* input) { return pg_query_parse_protobuf(input); }
+void STDCALL pg_query_free_protobuf_parse_result_wrapper(PgQueryProtobufParseResult result) { pg_query_free_protobuf_parse_result(result); }
+PgQueryParseResult STDCALL pg_query_parse_wrapper(const char* input) { return pg_query_parse(input); }
+void STDCALL pg_query_free_parse_result_wrapper(PgQueryParseResult result) { pg_query_free_parse_result(result); }
+PgQueryNormalizeResult STDCALL pg_query_normalize_wrapper(const char* input) { return pg_query_normalize(input); }
+void STDCALL pg_query_free_normalize_result_wrapper(PgQueryNormalizeResult result) { pg_query_free_normalize_result(result); }
+"@ | Set-Content -Path $WrapperPath -Encoding Ascii
 
-void pg_query_free_protobuf_parse_result_wrapper(PgQueryProtobufParseResult result) {
-    pg_query_free_protobuf_parse_result(result);
-}
-
-PgQueryDeparseResult pg_query_deparse_protobuf_wrapper(PgQueryProtobuf parse_tree) {
-    return pg_query_deparse_protobuf(parse_tree);
-}
-
-PgQueryParseResult pg_query_parse_wrapper(const char* input) {
-    return pg_query_parse(input);
-}
-
-void pg_query_free_parse_result_wrapper(PgQueryParseResult result) {
-    pg_query_free_parse_result(result);
-}
-
-PgQueryNormalizeResult pg_query_normalize_wrapper(const char* input) {
-    return pg_query_normalize(input);
-}
-
-void pg_query_free_normalize_result_wrapper(PgQueryNormalizeResult result) {
-    pg_query_free_normalize_result(result);
-}
-"@ | Set-Content $WrapperPath -Encoding ascii
-    }
+    Write-Host "Creating wrapper.def to export functions..."
+    @"
+EXPORTS
+    pg_query_parse_protobuf_wrapper
+    pg_query_free_protobuf_parse_result_wrapper
+    pg_query_parse_wrapper
+    pg_query_free_parse_result_wrapper
+    pg_query_normalize_wrapper
+    pg_query_free_normalize_result_wrapper
+"@ | Set-Content -Path $DefPath -Encoding Ascii
 
     $ClPath = Get-Command cl.exe -ErrorAction SilentlyContinue
-    if (-not $ClPath) {
-        Write-Error "cl.exe not found. Ensure Visual Studio Build Tools are installed and vcvars are loaded."
-        exit 1
-    }
+    if (-not $ClPath) { Write-Error "cl.exe not found. Ensure Visual Studio Build Tools are installed and vcvars are loaded."; exit 1 }
 
-    & $ClPath /nologo /LD /I libpg_query $WrapperPath libpg_query\pg_query.lib /link /OUT:libpgquery_wrapper.dll
-    if ($LASTEXITCODE -ne 0) {
-        Write-Error "❌ Failed to compile wrapper library"
-        exit $LASTEXITCODE
-    }
+    & $ClPath /nologo /LD /I "libpg_query" $WrapperPath "libpg_query\pg_query.lib" /DEF:$DefPath /link /OUT:libpgquery_wrapper.dll
+    if ($LASTEXITCODE -ne 0) { Write-Error "❌ Failed to compile wrapper library"; exit $LASTEXITCODE }
 }
 
-# Step 3: Create runtime directories and copy libraries
+# Step 3: Place native library for the .NET SDK and NuGet packaging
 if (-not $SkipNative) {
-    Write-Host "📁 Setting up runtime directories..." -ForegroundColor Yellow
-    
-    $RuntimeDir = "runtimes\$TargetRid\native"
-    New-Item -Path $RuntimeDir -ItemType Directory -Force | Out-Null
-    
-    # Copy libraries (both .dll and .lib if they exist)
-    $LibraryFiles = @("libpg_query.dll", "libpg_query.lib", "libpgquery_wrapper.dll", "pg_query.dll")
-    
-    foreach ($lib in $LibraryFiles) {
-        if (Test-Path "libpg_query\$lib") {
-            Write-Host "Copying $lib to $RuntimeDir"
-            Copy-Item "libpg_query\$lib" $RuntimeDir -Force
-        }
-    }
-    
-    # Also copy to project runtimes directory
+    Write-Host "📁 Placing native library for .NET SDK..." -ForegroundColor Yellow
     $ProjectRuntimeDir = "src\GrepSQL\runtimes\$TargetRid\native"
     New-Item -Path $ProjectRuntimeDir -ItemType Directory -Force | Out-Null
     
-    foreach ($lib in $LibraryFiles) {
-        if (Test-Path "libpg_query\$lib") {
-            Copy-Item "libpg_query\$lib" $ProjectRuntimeDir -Force
-        }
+    $sourceDll = "libpgquery_wrapper.dll"
+    if (Test-Path $sourceDll) {
+        Copy-Item $sourceDll $ProjectRuntimeDir -Force
+        Write-Host "✅ Copied $sourceDll to $ProjectRuntimeDir" -ForegroundColor Green
+    }
+    else {
+        Write-Error "❌ Could not find compiled $sourceDll in project root."
     }
 }
+
 
 # Step 4: Generate protobuf files
 if (-not $SkipProtobuf) {
     Write-Host "🔧 Generating protobuf files..." -ForegroundColor Yellow
-    
-    # Check for protoc
-    $ProtocPath = Get-Command protoc -ErrorAction SilentlyContinue
-    if (-not $ProtocPath) {
-        Write-Warning "⚠️  protoc not found. Attempting to install via dotnet tool..."
-        & dotnet tool install --global protobuf-net.Protogen --version 3.2.26
-        
-        # Try again
-        $ProtocPath = Get-Command protoc -ErrorAction SilentlyContinue
-        if (-not $ProtocPath) {
-            Write-Error "❌ Could not find or install protoc. Please install Protocol Buffers compiler manually."
-            exit 1
-        }
+    if (-not (Get-Command protoc -ErrorAction SilentlyContinue)) {
+        Write-Warning "⚠️  protoc not found. Please ensure it's installed and in the PATH."
+    }
+    if (-not (Test-Path "$env:USERPROFILE\.nuget\packages\grpc.tools")) {
+        Write-Host "Installing Grpc.Tools NuGet package..."
+        & dotnet add "src\GrepSQL" package Grpc.Tools
     }
     
-    # Add Grpc.Tools if not present
-    $GrpcToolsPath = "$env:USERPROFILE\.nuget\packages\grpc.tools"
-    if (-not (Test-Path $GrpcToolsPath)) {
-        Write-Host "Installing Grpc.Tools..."
-        & dotnet add "src\GrepSQL" package Grpc.Tools --version 2.72.0
-    }
-    
-    # Find the latest version and appropriate platform tools
-    $LatestVersion = Get-ChildItem $GrpcToolsPath | Sort-Object Name -Descending | Select-Object -First 1
-    $PluginPath = "$($LatestVersion.FullName)\tools\windows_x64"
-    
-    if (-not (Test-Path $PluginPath)) {
-        $PluginPath = "$($LatestVersion.FullName)\tools\windows_x86"
-    }
-    
-    $env:PATH = "$env:PATH;$PluginPath"
-    
-    # Generate protobuf files
     $ProtoSrc = "libpg_query\protobuf"
     $ProtoOut = "src\GrepSQL\AST\Generated"
-    
     New-Item -Path $ProtoOut -ItemType Directory -Force | Out-Null
-    
-    # Clean previous files
-    Get-ChildItem "$ProtoOut\*.cs" -ErrorAction SilentlyContinue | Remove-Item -Force
     
     Write-Host "Generating C# protobuf classes..."
     & protoc --proto_path="$ProtoSrc" --csharp_out="$ProtoOut" --csharp_opt=file_extension=.g.cs "$ProtoSrc\pg_query.proto"
-    
-    if ($LASTEXITCODE -ne 0) {
-        Write-Error "❌ Protobuf generation failed"
-        exit $LASTEXITCODE
-    }
-    
-    # Verify generated files
-    if (-not (Test-Path "$ProtoOut\PgQuery.g.cs")) {
-        Write-Error "❌ Expected protobuf files not generated"
-        exit 1
-    }
-    
+    if ($LASTEXITCODE -ne 0) { Write-Error "❌ Protobuf generation failed"; exit $LASTEXITCODE }
+    if (-not (Test-Path "$ProtoOut\PgQuery.g.cs")) { Write-Error "❌ Expected protobuf files not generated"; exit 1 }
     Write-Host "✅ Protobuf generation completed" -ForegroundColor Green
 }
 
-# Step 5: Build .NET project
+# Step 5: Build and Test .NET project
 if (-not $SkipBuild) {
-    Write-Host "🔨 Building .NET project..." -ForegroundColor Yellow
-    
-    & dotnet restore
-    if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-    
-    & dotnet build --configuration $Configuration --verbosity minimal
-    if ($LASTEXITCODE -ne 0) {
-        Write-Error "❌ Build failed"
-        exit $LASTEXITCODE
-    }
+    Write-Host "🔨 Building .NET projects for runtime $TargetRid..." -ForegroundColor Yellow
+
+    # Build the test project. This will automatically build the main project (its dependency)
+    # with the correct runtime context, avoiding solution platform errors.
+    $buildArgs = @(
+        "build",
+        "tests\GrepSQL.Tests\GrepSQL.Tests.csproj",
+        "--configuration", $Configuration,
+        "--runtime", $TargetRid
+    )
+    & dotnet @buildArgs
+    if ($LASTEXITCODE -ne 0) { Write-Error "❌ Build failed"; exit $LASTEXITCODE }
     
     Write-Host "✅ Build completed successfully" -ForegroundColor Green
     
-    # Run tests if they exist
     if (Test-Path "tests\GrepSQL.Tests.csproj") {
-        Write-Host "🧪 Running tests..." -ForegroundColor Yellow
-        & dotnet test --configuration $Configuration --verbosity minimal
+        Write-Host "🧪 Running tests for runtime $TargetRid..." -ForegroundColor Yellow
+        
+        # Test with --no-build as the projects were just built.
+        # This ensures we test the exact artifacts from the previous step.
+        $testArgs = @(
+            "test",
+            "tests\GrepSQL.Tests\GrepSQL.Tests.csproj",
+            "--configuration", $Configuration,
+            "--runtime", $TargetRid,
+            "--no-build",
+            "--verbosity", "normal"
+        )
+        & dotnet @testArgs
         if ($LASTEXITCODE -ne 0) {
-            Write-Warning "⚠️  Tests failed"
+            Write-Error "❌ Tests failed. Please review the output."
+            exit $LASTEXITCODE
         }
     }
+
+    Write-Host "✅ Tests passed successfully!" -ForegroundColor Green
     
-    # Create NuGet package
     Write-Host "📦 Creating NuGet package..." -ForegroundColor Yellow
     New-Item -Path "artifacts" -ItemType Directory -Force | Out-Null
-    & dotnet pack "src\GrepSQL" --configuration $Configuration --output "artifacts"
+    $packArgs = @(
+        "pack",
+        "src\GrepSQL\GrepSQL.csproj",
+        "--configuration", $Configuration,
+        "--output", "artifacts",
+        "--no-build" # We've already built, just pack the results.
+    )
+    & dotnet @packArgs
 }
 
 Write-Host ""
-Write-Host "🎉 Build completed successfully!" -ForegroundColor Green
-Write-Host ""
-Write-Host "📊 Build Summary:" -ForegroundColor Cyan
-Write-Host "  Target RID: $TargetRid"
-Write-Host "  Configuration: $Configuration"
-
-if (Test-Path "runtimes\$TargetRid\native") {
-    Write-Host "  Generated Libraries:"
-    Get-ChildItem "runtimes\$TargetRid\native" | ForEach-Object { Write-Host "    $($_.Name)" }
-}
-
-if (Test-Path "src\GrepSQL\AST\Generated") {
-    Write-Host "  Generated Protobuf Files:"
-    Get-ChildItem "src\GrepSQL\AST\Generated\*.cs" | ForEach-Object { Write-Host "    $($_.Name)" }
-}
-
-if (Test-Path "artifacts") {
-    Write-Host "  NuGet Packages:"
-    Get-ChildItem "artifacts\*.nupkg" | ForEach-Object { Write-Host "    $($_.Name)" }
-} 
+Write-Host "🎉 Build process completed successfully!" -ForegroundColor Green

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -74,18 +74,20 @@ if (-not $SkipNative) {
     $WrapperPath = Join-Path $ProjectRoot "wrapper.c"
     $DefPath = Join-Path $ProjectRoot "wrapper.def"
 
-    Write-Host "Creating wrapper.c with __stdcall calling convention..."
+    Write-Host "Creating wrapper.c with exported functions..." 
     @"
 #include "libpg_query/pg_query.h"
+#define EXPORT __declspec(dllexport)
 #define STDCALL __stdcall
 
-PgQueryProtobufParseResult STDCALL pg_query_parse_protobuf_wrapper(const char* input) { return pg_query_parse_protobuf(input); }
-void STDCALL pg_query_free_protobuf_parse_result_wrapper(PgQueryProtobufParseResult result) { pg_query_free_protobuf_parse_result(result); }
-PgQueryParseResult STDCALL pg_query_parse_wrapper(const char* input) { return pg_query_parse(input); }
-void STDCALL pg_query_free_parse_result_wrapper(PgQueryParseResult result) { pg_query_free_parse_result(result); }
-PgQueryNormalizeResult STDCALL pg_query_normalize_wrapper(const char* input) { return pg_query_normalize(input); }
-void STDCALL pg_query_free_normalize_result_wrapper(PgQueryNormalizeResult result) { pg_query_free_normalize_result(result); }
+EXPORT PgQueryProtobufParseResult STDCALL pg_query_parse_protobuf_wrapper(const char* input) { return pg_query_parse_protobuf(input); }
+EXPORT void STDCALL pg_query_free_protobuf_parse_result_wrapper(PgQueryProtobufParseResult result) { pg_query_free_protobuf_parse_result(result); }
+EXPORT PgQueryParseResult STDCALL pg_query_parse_wrapper(const char* input) { return pg_query_parse(input); }
+EXPORT void STDCALL pg_query_free_parse_result_wrapper(PgQueryParseResult result) { pg_query_free_parse_result(result); }
+EXPORT PgQueryNormalizeResult STDCALL pg_query_normalize_wrapper(const char* input) { return pg_query_normalize(input); }
+EXPORT void STDCALL pg_query_free_normalize_result_wrapper(PgQueryNormalizeResult result) { pg_query_free_normalize_result(result); }
 "@ | Set-Content -Path $WrapperPath -Encoding Ascii
+
 
     Write-Host "Creating wrapper.def to export functions..."
     @"

--- a/src/GrepSQL/GrepSQL.csproj
+++ b/src/GrepSQL/GrepSQL.csproj
@@ -11,12 +11,15 @@
     <Title>GrepSQL</Title>
     <Authors>Jônatas Davi Paganini</Authors>
     <Description>
-      A .NET wrapper for libpg_query - parse, normalize, and fingerprint PostgreSQL queries using the actual PostgreSQL parser.
+      A .NET wrapper for libpg_query - parse, normalize, and fingerprint PostgreSQL queries using
+      the actual PostgreSQL parser.
       You can also use it to analyze queries and find patterns using a simple DSL inspired by grep.
-      It's a wrapper for the [libpg_query](https://github.com/pganalyze/libpg_query) library, which is a C library that provides a parser for PostgreSQL.
+      It's a wrapper for the [libpg_query](https://github.com/pganalyze/libpg_query) library, which
+      is a C library that provides a parser for PostgreSQL.
       Uses protobuf to serialize and deserialize the AST.
     </Description>
-    <PackageTags>postgresql;sql;parser;search;grep;cli;libpg_query;pgquery;ast;query;analysis;pattern;matching;find;replace;rewrite</PackageTags>
+    <PackageTags>
+      postgresql;sql;parser;search;grep;cli;libpg_query;pgquery;ast;query;analysis;pattern;matching;find;replace;rewrite</PackageTags>
     <RepositoryUrl>https://github.com/jonatas/grepsql</RepositoryUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
@@ -43,7 +46,13 @@
     <PgQueryWrapperLinux>libpgquery_wrapper.so</PgQueryWrapperLinux>
     <PgQueryWrapperMac>libpgquery_wrapper.dylib</PgQueryWrapperMac>
   </PropertyGroup>
-
+  <ItemGroup>
+    <None Include="runtimes\win-x64\native\libpgquery_wrapper.dll">
+      <Pack>true</Pack>
+      <PackagePath>runtimes/win-x64/native/libpgquery_wrapper.dll</PackagePath>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.31.1" />
     <PackageReference Include="Google.Protobuf.Tools" Version="3.31.1" />
@@ -55,24 +64,28 @@
 
   <!-- Native libraries for Windows -->
   <ItemGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
-    <Content Include="runtimes\win-x64\native\$(PgQueryWrapperWin)" Condition="Exists('runtimes\win-x64\native\$(PgQueryWrapperWin)')">
+    <Content Include="runtimes\win-x64\native\$(PgQueryWrapperWin)"
+      Condition="Exists('runtimes\win-x64\native\$(PgQueryWrapperWin)')">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <PackagePath>runtimes\win-x64\native\$(PgQueryWrapperWin)</PackagePath>
       <Pack>true</Pack>
     </Content>
-    <Content Include="runtimes\win-x86\native\$(PgQueryWrapperWin)" Condition="Exists('runtimes\win-x86\native\$(PgQueryWrapperWin)')">
+    <Content Include="runtimes\win-x86\native\$(PgQueryWrapperWin)"
+      Condition="Exists('runtimes\win-x86\native\$(PgQueryWrapperWin)')">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <PackagePath>runtimes\win-x86\native\$(PgQueryWrapperWin)</PackagePath>
       <Pack>true</Pack>
     </Content>
-    <Content Include="runtimes\win-arm64\native\$(PgQueryWrapperWin)" Condition="Exists('runtimes\win-arm64\native\$(PgQueryWrapperWin)')">
+    <Content Include="runtimes\win-arm64\native\$(PgQueryWrapperWin)"
+      Condition="Exists('runtimes\win-arm64\native\$(PgQueryWrapperWin)')">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <PackagePath>runtimes\win-arm64\native\$(PgQueryWrapperWin)</PackagePath>
       <Pack>true</Pack>
     </Content>
-    
+
     <!-- Fallback: Copy wrapper library directly to output directory for better compatibility -->
-    <Content Include="runtimes\win-x64\native\$(PgQueryWrapperWin)" Condition="Exists('runtimes\win-x64\native\$(PgQueryWrapperWin)')">
+    <Content Include="runtimes\win-x64\native\$(PgQueryWrapperWin)"
+      Condition="Exists('runtimes\win-x64\native\$(PgQueryWrapperWin)')">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>$(PgQueryWrapperWin)</Link>
     </Content>
@@ -80,19 +93,22 @@
 
   <!-- Native libraries for Linux -->
   <ItemGroup Condition="$([MSBuild]::IsOSPlatform('Linux'))">
-    <Content Include="runtimes\linux-x64\native\$(PgQueryWrapperLinux)" Condition="Exists('runtimes\linux-x64\native\$(PgQueryWrapperLinux)')">
+    <Content Include="runtimes\linux-x64\native\$(PgQueryWrapperLinux)"
+      Condition="Exists('runtimes\linux-x64\native\$(PgQueryWrapperLinux)')">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <PackagePath>runtimes\linux-x64\native\$(PgQueryWrapperLinux)</PackagePath>
       <Pack>true</Pack>
     </Content>
-    <Content Include="runtimes\linux-arm64\native\$(PgQueryWrapperLinux)" Condition="Exists('runtimes\linux-arm64\native\$(PgQueryWrapperLinux)')">
+    <Content Include="runtimes\linux-arm64\native\$(PgQueryWrapperLinux)"
+      Condition="Exists('runtimes\linux-arm64\native\$(PgQueryWrapperLinux)')">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <PackagePath>runtimes\linux-arm64\native\$(PgQueryWrapperLinux)</PackagePath>
       <Pack>true</Pack>
     </Content>
-    
+
     <!-- Fallback: Copy wrapper library directly to output directory for better compatibility -->
-    <Content Include="runtimes\linux-x64\native\$(PgQueryWrapperLinux)" Condition="Exists('runtimes\linux-x64\native\$(PgQueryWrapperLinux)')">
+    <Content Include="runtimes\linux-x64\native\$(PgQueryWrapperLinux)"
+      Condition="Exists('runtimes\linux-x64\native\$(PgQueryWrapperLinux)')">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>$(PgQueryWrapperLinux)</Link>
     </Content>
@@ -100,22 +116,24 @@
 
   <!-- Native libraries for macOS -->
   <ItemGroup Condition="$([MSBuild]::IsOSPlatform('OSX'))">
-    <Content Include="runtimes\osx-x64\native\$(PgQueryWrapperMac)" Condition="Exists('runtimes\osx-x64\native\$(PgQueryWrapperMac)')">
+    <Content Include="runtimes\osx-x64\native\$(PgQueryWrapperMac)"
+      Condition="Exists('runtimes\osx-x64\native\$(PgQueryWrapperMac)')">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <PackagePath>runtimes\osx-x64\native\$(PgQueryWrapperMac)</PackagePath>
       <Pack>true</Pack>
     </Content>
-    <Content Include="runtimes\osx-arm64\native\$(PgQueryWrapperMac)" Condition="Exists('runtimes\osx-arm64\native\$(PgQueryWrapperMac)')">
+    <Content Include="runtimes\osx-arm64\native\$(PgQueryWrapperMac)"
+      Condition="Exists('runtimes\osx-arm64\native\$(PgQueryWrapperMac)')">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <PackagePath>runtimes\osx-arm64\native\$(PgQueryWrapperMac)</PackagePath>
       <Pack>true</Pack>
     </Content>
-    
+
     <!-- Fallback: Copy wrapper library directly to output directory for better compatibility -->
-    <Content Include="runtimes\osx-arm64\native\$(PgQueryWrapperMac)" Condition="Exists('runtimes\osx-arm64\native\$(PgQueryWrapperMac)')">
+    <Content Include="runtimes\osx-arm64\native\$(PgQueryWrapperMac)"
+      Condition="Exists('runtimes\osx-arm64\native\$(PgQueryWrapperMac)')">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>$(PgQueryWrapperMac)</Link>
     </Content>
   </ItemGroup>
 </Project>
-

--- a/src/GrepSQL/GrepSQL.csproj
+++ b/src/GrepSQL/GrepSQL.csproj
@@ -19,7 +19,8 @@
       Uses protobuf to serialize and deserialize the AST.
     </Description>
     <PackageTags>
-      postgresql;sql;parser;search;grep;cli;libpg_query;pgquery;ast;query;analysis;pattern;matching;find;replace;rewrite</PackageTags>
+      postgresql;sql;parser;search;grep;cli;libpg_query;pgquery;ast;query;analysis;pattern;matching;find;replace;rewrite
+    </PackageTags>
     <RepositoryUrl>https://github.com/jonatas/grepsql</RepositoryUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
@@ -28,6 +29,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
+  <!-- Platform-specific compilation symbols -->
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('OSX'))">
     <DefineConstants>__MACOS__</DefineConstants>
   </PropertyGroup>
@@ -40,19 +42,14 @@
     <DefineConstants>__WINDOWS__</DefineConstants>
   </PropertyGroup>
 
+  <!-- Native library file names per platform -->
   <PropertyGroup>
-    <!-- Define native library names for different platforms -->
     <PgQueryWrapperWin>pgquery_wrapper.dll</PgQueryWrapperWin>
     <PgQueryWrapperLinux>libpgquery_wrapper.so</PgQueryWrapperLinux>
     <PgQueryWrapperMac>libpgquery_wrapper.dylib</PgQueryWrapperMac>
   </PropertyGroup>
-  <ItemGroup>
-    <None Include="runtimes\win-x64\native\libpgquery_wrapper.dll">
-      <Pack>true</Pack>
-      <PackagePath>runtimes/win-x64/native/libpgquery_wrapper.dll</PackagePath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
+
+  <!-- NuGet packages -->
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.31.1" />
     <PackageReference Include="Google.Protobuf.Tools" Version="3.31.1" />
@@ -62,7 +59,7 @@
     </PackageReference>
   </ItemGroup>
 
-  <!-- Native libraries for Windows -->
+  <!-- Windows native libraries -->
   <ItemGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
     <Content Include="runtimes\win-x64\native\$(PgQueryWrapperWin)"
       Condition="Exists('runtimes\win-x64\native\$(PgQueryWrapperWin)')">
@@ -82,8 +79,6 @@
       <PackagePath>runtimes\win-arm64\native\$(PgQueryWrapperWin)</PackagePath>
       <Pack>true</Pack>
     </Content>
-
-    <!-- Fallback: Copy wrapper library directly to output directory for better compatibility -->
     <Content Include="runtimes\win-x64\native\$(PgQueryWrapperWin)"
       Condition="Exists('runtimes\win-x64\native\$(PgQueryWrapperWin)')">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -91,7 +86,7 @@
     </Content>
   </ItemGroup>
 
-  <!-- Native libraries for Linux -->
+  <!-- Linux native libraries -->
   <ItemGroup Condition="$([MSBuild]::IsOSPlatform('Linux'))">
     <Content Include="runtimes\linux-x64\native\$(PgQueryWrapperLinux)"
       Condition="Exists('runtimes\linux-x64\native\$(PgQueryWrapperLinux)')">
@@ -105,8 +100,6 @@
       <PackagePath>runtimes\linux-arm64\native\$(PgQueryWrapperLinux)</PackagePath>
       <Pack>true</Pack>
     </Content>
-
-    <!-- Fallback: Copy wrapper library directly to output directory for better compatibility -->
     <Content Include="runtimes\linux-x64\native\$(PgQueryWrapperLinux)"
       Condition="Exists('runtimes\linux-x64\native\$(PgQueryWrapperLinux)')">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -114,7 +107,7 @@
     </Content>
   </ItemGroup>
 
-  <!-- Native libraries for macOS -->
+  <!-- macOS native libraries -->
   <ItemGroup Condition="$([MSBuild]::IsOSPlatform('OSX'))">
     <Content Include="runtimes\osx-x64\native\$(PgQueryWrapperMac)"
       Condition="Exists('runtimes\osx-x64\native\$(PgQueryWrapperMac)')">
@@ -128,12 +121,11 @@
       <PackagePath>runtimes\osx-arm64\native\$(PgQueryWrapperMac)</PackagePath>
       <Pack>true</Pack>
     </Content>
-
-    <!-- Fallback: Copy wrapper library directly to output directory for better compatibility -->
     <Content Include="runtimes\osx-arm64\native\$(PgQueryWrapperMac)"
       Condition="Exists('runtimes\osx-arm64\native\$(PgQueryWrapperMac)')">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>$(PgQueryWrapperMac)</Link>
     </Content>
   </ItemGroup>
+
 </Project>

--- a/src/GrepSQL/NativeLibraryLoader.cs
+++ b/src/GrepSQL/NativeLibraryLoader.cs
@@ -22,7 +22,7 @@ namespace GrepSQL
                 {
                     var assemblyLocation = Assembly.GetExecutingAssembly().Location;
                     var assemblyDirectory = Path.GetDirectoryName(assemblyLocation);
-                    
+
                     // More robust runtime identification
                     var rid = GetRuntimeIdentifier();
                     var libraryName = GetLibraryFileName();
@@ -68,11 +68,11 @@ namespace GrepSQL
             var rid = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "win-" :
                      RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? "linux-" :
                      RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "osx-" : "any-";
-            
+
             rid += RuntimeInformation.ProcessArchitecture switch
             {
                 Architecture.X64 => "x64",
-                Architecture.X86 => "x86", 
+                Architecture.X86 => "x86",
                 Architecture.Arm64 => "arm64",
                 Architecture.Arm => "arm",
                 _ => "x64"
@@ -86,13 +86,13 @@ namespace GrepSQL
             // Handle M1 Mac fallback
             if (primaryRid == "osx-arm64")
                 return new[] { "osx-x64", "osx-arm64" };
-            
+
             if (primaryRid.StartsWith("linux-"))
                 return new[] { "linux-x64", primaryRid };
-                
+
             if (primaryRid.StartsWith("win-"))
                 return new[] { "win-x64", "win-x86", primaryRid };
-                
+
             return new[] { primaryRid };
         }
 
@@ -126,7 +126,7 @@ namespace GrepSQL
             }
         }
 
-        [DllImport("kernel32", SetLastError = true, CharSet = CharSet.Unicode)]
+        [DllImport("kernel32.dll", EntryPoint = "LoadLibraryW", SetLastError = true, CharSet = CharSet.Unicode)]
         private static extern IntPtr LoadLibraryWindows(string lpFileName);
 
         [DllImport("libdl", CharSet = CharSet.Ansi)]


### PR DESCRIPTION
This pull request adds an explicit `permissions` block to the **Build and Release Binaries** GitHub Actions workflow. By granting the `GITHUB_TOKEN` write access to repository contents and packages, it ensures that the `softprops/action-gh-release` step can successfully create or update Releases without encountering a 403 Forbidden error.